### PR TITLE
Use Layout-based flow layout for tags

### DIFF
--- a/Quotex/Tags/TagsView.swift
+++ b/Quotex/Tags/TagsView.swift
@@ -13,16 +13,18 @@ struct TagsView: View {
 
   var body: some View {
     ScrollView {
-      FlowLayout(viewModel.tags) { tag in
-        Button(action: {
-          viewModel.selectTag(for: tag)
-        }, label: {
-          Text(tag.name)
-            .bold()
-            .foregroundColor(.black)
-            .padding()
-            .overlay(RoundedRectangle(cornerRadius: 8).stroke(.gray, lineWidth: 1.5))
-        })
+      NewFlowLayout {
+        ForEach(viewModel.tags) { tag in
+          Button(action: {
+            viewModel.selectTag(for: tag)
+          }, label: {
+            Text(tag.name)
+              .bold()
+              .foregroundColor(.black)
+              .padding()
+              .overlay(RoundedRectangle(cornerRadius: 8).stroke(.gray, lineWidth: 1.5))
+          })
+        }
       }
       .padding()
     }
@@ -57,4 +59,3 @@ struct TagsView_Previews: PreviewProvider {
     TagsView()
   }
 }
-


### PR DESCRIPTION
## Summary
- replace the legacy alignment-guide FlowLayout in TagsView with the iOS 16 Layout-based NewFlowLayout

## Verification
- xcodebuild -project Quotex.xcodeproj -scheme Quotex -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build

Closes #1